### PR TITLE
Fix typo in comment in maven.yml

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -51,9 +51,9 @@ jobs:
           gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
 
           # Commands to SSH into the VM and run the Docker commands 
-          gcloud compute ssh dev-rate-api --zone europe-west1-b --command "\ 
+          gcloud compute ssh dev-rate-api --zone europe-west1-b --command "
             source ~/.bashrc && \
-            sudo docker pull europe-west1-docker.pkg.dev/devrate-dev/dev-rate-service/dev-rate:latest || true && \
+            sudo docker pull europe-west1-docker.pkg.dev/devrate-dev/dev-rate-service/dev-rate:latest && \
             sudo docker stop dev-rate-container || true && \
             sudo docker rm dev-rate-container || true && \
             sudo docker run -d --name dev-rate-container -p 80:8080 \


### PR DESCRIPTION
Removed a typo in a comment in the maven.yml workflow file. Previously, an unintended string 'dfg' was added