### PR TITLE
Fix-swagger-for-specialization

### DIFF
--- a/src/main/resources/static/swagger-config.yaml
+++ b/src/main/resources/static/swagger-config.yaml
@@ -1409,7 +1409,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /user/{userId}/specializations:
+  /users/{userId}/specializations:
     get:
       tags:
         - Specialization


### PR DESCRIPTION
issue: https://github.com/orgs/ratifire/projects/6/views/1?pane=issue&itemId=67513641

fix path user/specializations/{id} -> users/specializations/{id}