### PR TITLE
Removed logic that update interview request at the matcher service wh…

### DIFF
--- a/src/main/java/com/ratifire/devrate/service/interview/InterviewRequestService.java
+++ b/src/main/java/com/ratifire/devrate/service/interview/InterviewRequestService.java
@@ -107,7 +107,6 @@ public class InterviewRequestService {
 
     if (hasExpiredSlots) {
       repository.saveAll(interviewRequests);
-      interviewRequests.forEach(matcherServiceQueueSender::update);
     }
   }
 


### PR DESCRIPTION
Minor fix related to expired time slots. So when a time slot has expired, we don't remove the time slot from the MongoDB (matcher). 